### PR TITLE
basic argparse implementation

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,31 +2,57 @@
 from qe.drivers import *
 from qe.io import *
 import sys
+import argparse
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Process  input arguments for Quantum Envelope calculation"
+    )
 
-    fcidump_path = sys.argv[1]
-    wf_path = sys.argv[2]
-    N_det_target = int(sys.argv[3])
-    try:
-        driven_by = sys.argv[4]
-    except IndexError:
-        driven_by = "integral"
+    parser.add_argument(
+        "--fcidump_path", help="path/filename of the FCIDUMP file containing integrals"
+    )
+    parser.add_argument(
+        "--wf_path",
+        help="path/filename of the wf file containing the wf coefficients and determinant list to begin with",
+    )
 
+    parser.add_argument(
+        "-N_det_target",
+        type=int,
+        default=int(1000),
+        required=False,
+        help="Number of determinants to target",
+    )
+
+    parser.add_argument(
+        "-driven_by",
+        choices=["integral", "determinant"],
+        default="integral",
+        required=False,
+        help="Way in which Hamiltonian is generated. Integral driven: local set of integrals, determinants are found on each node. Determinant driven: local set of determinants, all integrals are on each node.",
+    )
+
+    args = parser.parse_args()
     # Load integrals
-    n_ord, E0, d_one_e_integral, d_two_e_integral = load_integrals(fcidump_path)
+    n_ord, E0, d_one_e_integral, d_two_e_integral = load_integrals(args.fcidump_path)
     # Load wave function
-    psi_coef, psi_det = load_wf(wf_path)
+    psi_coef, psi_det = load_wf(args.wf_path)
     # Hamiltonian engine
     comm = MPI.COMM_WORLD
     lewis = Hamiltonian_generator(
-        comm, E0, d_one_e_integral, d_two_e_integral, psi_det, driven_by=driven_by
+        comm, E0, d_one_e_integral, d_two_e_integral, psi_det, driven_by=args.driven_by
     )
 
-    while len(psi_det) < N_det_target:
+    while len(psi_det) < args.N_det_target:
         E, psi_coef, psi_det = selection_step(comm, lewis, n_ord, psi_coef, psi_det, len(psi_det))
         # Update Hamiltonian engine
         lewis = Hamiltonian_generator(
-            comm, E0, d_one_e_integral, d_two_e_integral, psi_det, driven_by=driven_by
+            comm,
+            E0,
+            d_one_e_integral,
+            d_two_e_integral,
+            psi_det,
+            driven_by=args.driven_by,
         )
         print(f"N_det: {len(psi_det)}, E {E}")


### PR DESCRIPTION
This introduces argparse framework for those arguments that were being manually parsed.

This assumes  `fcidump_path` and `wf_path` are required. `driven_by` is optional and defaults to integral driven. 

`N_det_target` is optional, provides a very small default of 1000 for testing reasons.  Let me know if you would like the default to be an production calculation size such as 1000000.