### PR TITLE
NOs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from qe.drivers import *
 from qe.io import *
+from qe.no import *
 import sys
 import argparse
 
@@ -33,6 +34,14 @@ if __name__ == "__main__":
         help="Way in which Hamiltonian is generated. Integral driven: local set of integrals, determinants are found on each node. Determinant driven: local set of determinants, all integrals are on each node.",
     )
 
+    parser.add_argument(
+        "-NOs",
+        type=bool,
+        default=False,
+        required=False,
+        help="Construct Natural Orbitals?"
+    )
+
     args = parser.parse_args()
     # Load integrals
     n_ord, E0, d_one_e_integral, d_two_e_integral = load_integrals(args.fcidump_path)
@@ -56,3 +65,6 @@ if __name__ == "__main__":
             driven_by=args.driven_by,
         )
         print(f"N_det: {len(psi_det)}, E {E}")
+
+    if do_NOs:
+        no_occ, no_coeff = natural_orbitals(comm, lewis, n_orb, psi_coef, psi_det, n)

--- a/qe/drivers.py
+++ b/qe/drivers.py
@@ -121,9 +121,7 @@ class Excitation:
         apply_excitation_to_spindet = partial(Excitation.apply_excitation, spindet)
         return map(apply_excitation_to_spindet, l_exc)
 
-    def gen_all_connected_single_det_from_det(
-        self, det: Determinant
-    ) -> Iterator[Determinant]:
+    def gen_all_connected_single_det_from_det(self, det: Determinant) -> Iterator[Determinant]:
         """
         Generate all the determinant who are single excitation from the input determinant
 
@@ -170,18 +168,12 @@ class Excitation:
         l_single_a = set(self.gen_all_connected_spindet(det.alpha, 1))
         l_double_aa = self.gen_all_connected_spindet(det.alpha, 2)
 
-        s_a = (
-            Determinant(det_alpha, det.beta)
-            for det_alpha in chain(l_single_a, l_double_aa)
-        )
+        s_a = (Determinant(det_alpha, det.beta) for det_alpha in chain(l_single_a, l_double_aa))
 
         l_single_b = set(self.gen_all_connected_spindet(det.beta, 1))
         l_double_bb = self.gen_all_connected_spindet(det.beta, 2)
 
-        s_b = (
-            Determinant(det.alpha, det_beta)
-            for det_beta in chain(l_single_b, l_double_bb)
-        )
+        s_b = (Determinant(det.alpha, det_beta) for det_beta in chain(l_single_b, l_double_bb))
 
         l_double_ab = product(l_single_a, l_single_b)
 
@@ -2016,11 +2008,7 @@ class Powerplant_manager(object):
         """
         c = np.array(psi_coef, dtype="float")  # Coef. vector as np.array
         # Coeffs. of local determinants
-        c_i = c[
-            self.offsets[self.rank] : (
-                self.offsets[self.rank] + self.distribution[self.rank]
-            )
-        ]
+        c_i = c[self.offsets[self.rank] : (self.offsets[self.rank] + self.distribution[self.rank])]
         # Pre-allocate MO 1RDM
         local_mo_rdm = np.zeros(n_orb, n_orb)
 
@@ -2046,12 +2034,12 @@ class Powerplant_manager(object):
                 # calculate phase, index of hole, and index of particle between two determinants
                 if det_I.alpha == det_J.alpha:
                     # compute phase and hole particle index, returned as Tuple[phase,hole,particle].
-                    php_tuple = PhaseIdx.single_exc(det_I.alpha,det_J.alpha)
-                else: # not alpha_excitation:
-                    php_tuple = PhaseIdx.single_exc(det_I.beta,det_J.beta)
+                    php_tuple = PhaseIdx.single_exc(det_I.alpha, det_J.alpha)
+                else:  # not alpha_excitation:
+                    php_tuple = PhaseIdx.single_exc(det_I.beta, det_J.beta)
                 # account for spin average
-                local_mo_rdm[php_tuple[1], php_tuple[2]] += php_tuple[0]*coeff_ij*2
-                local_mo_rdm[php_tuple[2], php_tuple[1]] += php_tuple[0]*coeff_ij*2
+                local_mo_rdm[php_tuple[1], php_tuple[2]] += php_tuple[0] * coeff_ij * 2
+                local_mo_rdm[php_tuple[2], php_tuple[1]] += php_tuple[0] * coeff_ij * 2
 
         # reduce on local_rdm?
         return False

--- a/qe/drivers.py
+++ b/qe/drivers.py
@@ -2054,8 +2054,7 @@ class Powerplant_manager(object):
                 local_mo_rdm[php_tuple[2], php_tuple[1]] += php_tuple[0]*coeff_ij*2
 
         # reduce on local_rdm?
-
-    return False
+        return False
 
     def E_pt2(self, psi_coef: Psi_coef) -> Energy:
         # The sum of the pt2 contribution of each external determinant

--- a/qe/fundamental_types.py
+++ b/qe/fundamental_types.py
@@ -1,4 +1,5 @@
 from typing import Tuple, Dict, NamedTuple, List, NewType
+import numpy as np
 
 # Orbital index (0,1,2,...,n_orb-1)
 OrbitalIdx = NewType("OrbitalIdx", int)
@@ -25,6 +26,11 @@ class Determinant(NamedTuple):
 
 Psi_det = List[Determinant]
 Psi_coef = List[float]
+
+MO_1rdm = np.ndarray
+no_occ = np.ndarray
+no_coeff = np.ndarray
+
 # We have two type of energy.
 # The varitional Energy who correpond Psi_det
 # The pt2 Energy who correnpond to the pertubative energy induce by each determinant connected to Psi_det

--- a/qe/no.py
+++ b/qe/no.py
@@ -2,6 +2,7 @@ from drivers import Powerplant_manager
 from fundamental_types import *
 import numpy as np
 
+
 def get_MO_1rdm(comm, lewis, n_orb, psi_coef: Psi_coef, psi_det: Psi_det, n) -> MO_1rdm:
     return Powerplant_manager(comm, lewis).MO_1rdm(psi_coef, n, n_orb)
 

--- a/qe/no.py
+++ b/qe/no.py
@@ -1,3 +1,7 @@
+from drivers import Powerplant_manager
+from fundamental_types import *
+import numpy as np
+
 def get_MO_1rdm(comm, lewis, n_orb, psi_coef: Psi_coef, psi_det: Psi_det, n) -> MO_1rdm:
     return Powerplant_manager(comm, lewis).MO_1rdm(psi_coef, n, n_orb)
 

--- a/qe/no.py
+++ b/qe/no.py
@@ -1,0 +1,15 @@
+def get_MO_1rdm(comm, lewis, n_orb, psi_coef: Psi_coef, psi_det: Psi_det, n) -> MO_1rdm:
+    return Powerplant_manager(comm, lewis).MO_1rdm(psi_coef, n, n_orb)
+
+
+def natural_orbitals(
+    comm, lewis: Hamiltonian_generator, n_orb, psi_coef: Psi_coef, psi_det: Psi_det, n
+) -> Tuple[no_occ, no_coeff]:
+    # create MO 1 rdm
+    mo_1rdm = get_MO_1rdm(comm, lewis, n_orb, psi_coef, psi_det, n)
+    # diagonalize MO 1 rdm
+    no_occ, no_coeff_MO_basis = np.linalg.eigh(mo_1rdm)
+    no_occ = no_occ[::-1]
+    no_coeff = np.fliplr(no_coeff)
+    # transform MO 1 rdm to ao basis
+    # NEED AO BASIS FOR THIS


### PR DESCRIPTION
@amandadumi and I spent some time today and put the start of natural orbtials into the code.

We used this paper as a reference https://arxiv.org/abs/1311.6244

This should have each MPI process accumulate the contributions to the MO 1RDM for the local set of determinants.

Some points that need discussion/thinking
- There is no AO information so we won't be able to put these back into the AO basis
- Does anyone with more MPI knowledge know how we should efficiently combine each MPI process's local copy of the RDM? They are all numpy arrays

Still a WIP but let us know if anything looks egregiously wrong