### PR TITLE
Implement load files from Master Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/TApplencourt/QuantumEnvelope.svg?branch=master)](https://travis-ci.org/TApplencourt/QuantumEnvelope)
-
+  
 
 # How to run the tests
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,11 @@ import sys
 import argparse
 
 if __name__ == "__main__":
+    #initialize communicator
+    comm = MPI.COMM_WORLD
+    rank=comm.Get_rank()
+    verbose=True
+
     parser = argparse.ArgumentParser(
         description="Process  input arguments for Quantum Envelope calculation"
     )
@@ -14,7 +19,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--wf_path",
-        help="path/filename of the wf file containing the wf coefficients and determinant list to begin with",
+        default="Guess",
+        required=False,
+        help="path/filename of the wf file containing the wf coefficients and determinant list to begin with. If nothing provided, the starting point will be 1 determinant with a weight of 1.0",
     )
 
     parser.add_argument(
@@ -32,20 +39,20 @@ if __name__ == "__main__":
         required=False,
         help="Way in which Hamiltonian is generated. Integral driven: local set of integrals, determinants are found on each node. Determinant driven: local set of determinants, all integrals are on each node.",
     )
-
     args = parser.parse_args()
     # Load integrals
-    n_ord, E0, d_one_e_integral, d_two_e_integral = load_integrals(args.fcidump_path)
+    n_elec, n_orb, E0, d_one_e_integral, d_two_e_integral = load_integrals(args.fcidump_path)
     # Load wave function
-    psi_coef, psi_det = load_wf(args.wf_path)
+    
+    psi_coef, psi_det = load_wf(n_elec,n_orb,args.wf_path)
     # Hamiltonian engine
-    comm = MPI.COMM_WORLD
+
     lewis = Hamiltonian_generator(
         comm, E0, d_one_e_integral, d_two_e_integral, psi_det, driven_by=args.driven_by
     )
 
     while len(psi_det) < args.N_det_target:
-        E, psi_coef, psi_det = selection_step(comm, lewis, n_ord, psi_coef, psi_det, len(psi_det))
+        E, psi_coef, psi_det, E_pt2 = selection_step(comm, lewis, n_orb, psi_coef, psi_det, len(psi_det))
         # Update Hamiltonian engine
         lewis = Hamiltonian_generator(
             comm,
@@ -55,4 +62,5 @@ if __name__ == "__main__":
             psi_det,
             driven_by=args.driven_by,
         )
-        print(f"N_det: {len(psi_det)}, E {E}")
+        if rank==0:
+            print(f"N_det: {len(psi_det)}, E: {E}, E_PT2: {E_pt2}")

--- a/qe/drivers.py
+++ b/qe/drivers.py
@@ -4,6 +4,7 @@ from itertools import chain, product, combinations, takewhile, permutations, acc
 from functools import partial, cached_property, cache
 from collections import defaultdict
 import numpy as np
+import time
 
 # Import mpi4py and utilities
 from mpi4py import MPI  # Note this initializes and finalizes MPI session automatically
@@ -1546,7 +1547,7 @@ class Davidson_manager(object):
     Each process will have local access to instance of the `Hamiltonian_generator()' class, to construct
     the local portion Hamiltonian on the fly.
     """
-
+    
     def __init__(self, comm, H_i_generator: Hamiltonian_generator):
         self.comm = comm
         self.world_size = self.comm.Get_size()  # No. of processes running
@@ -2009,4 +2010,4 @@ def selection_step(
         psi_det_extented,
     )  # Can optimize to only do this once
 
-    return (*Powerplant_manager(comm, lewis_new).E_and_psi_coef, psi_det_extented)
+    return (*Powerplant_manager(comm, lewis_new).E_and_psi_coef, psi_det_extented,sum(psi_external_energy))

--- a/qe/io.py
+++ b/qe/io.py
@@ -128,6 +128,10 @@ def load_wf(n_elec,n_orb,path_wf) -> Tuple[List[float], List[Determinant]]:
     psi_coef = []
 
     if(rank==0): 
+       def decode_det(str_):
+          for i, v in enumerate(str_):
+              if v == "+":
+                  yield i
        if (path_wf!="Guess"):
           if len(glob.glob(path_wf)) == 1:
               path_wf = glob.glob(path_wf)[0]
@@ -152,11 +156,6 @@ def load_wf(n_elec,n_orb,path_wf) -> Tuple[List[float], List[Determinant]]:
               with open(path_wf) as f:
                   data = f.read().split()
       
-          def decode_det(str_):
-              for i, v in enumerate(str_):
-                  if v == "+":
-                      yield i
-      
           def grouper(iterable, n):
               "Collect data into fixed-length chunks or blocks"
               args = [iter(iterable)] * n
@@ -165,14 +164,13 @@ def load_wf(n_elec,n_orb,path_wf) -> Tuple[List[float], List[Determinant]]:
               psi_coef.append(float(coef))
               det.append(Determinant(tuple(decode_det(det_i)), tuple(decode_det(det_j))))
        else:
-          print("Bazinga")
+          print("Starting from HF guess - 1 determinant")
           coef=1.0
           alpha=math.ceil(n_elec/2)
           beta=n_elec-alpha
           psi_coef.append(float(coef))
-          #$This is Wrong!!!! Needs fixing!!!!
-          det_i="+++++------" 
-          det_j="+++++------" 
+          det_i = "+"*alpha + "-" * (n_orb - alpha)
+          det_j = "+"*beta + "-" * (n_orb - beta)
           det.append(Determinant(tuple(decode_det(det_i)), tuple(decode_det(det_j))))
  
  

--- a/qe/io.py
+++ b/qe/io.py
@@ -9,7 +9,9 @@ from qe.fundamental_types import (
 from collections import defaultdict
 from qe.integral_indexing_utils import compound_idx4
 import math
+import time
 
+from mpi4py import MPI  # Note this initializes and finalizes MPI session automatically
 #   _____      _ _   _       _ _          _   _
 #  |_   _|    (_) | (_)     | (_)        | | (_)
 #    | | _ __  _| |_ _  __ _| |_ ______ _| |_ _  ___  _ __
@@ -20,126 +22,168 @@ import math
 # ~
 # Integrals of the Hamiltonian over molecular orbitals
 # ~
-def load_integrals(
-    fcidump_path,
+def load_integrals(fcidump_path,
 ) -> Tuple[int, float, One_electron_integral, Two_electron_integral]:
     """Read all the Hamiltonian integrals from the data file.
     Returns: (E0, d_one_e_integral, d_two_e_integral).
+    n_elec:  an integer containing the number of electrons in the system
+    n_orb : an integer containing the number of orbitals in the system
     E0 : a float containing the nuclear repulsion energy (V_nn),
     d_one_e_integral : a dictionary of one-electron integrals,
     d_two_e_integral : a dictionary of two-electron integrals.
     """
-    import glob
+    comm=MPI.COMM_WORLD
+    rank=comm.Get_rank()
 
-    if len(glob.glob(fcidump_path)) == 1:
-        fcidump_path = glob.glob(fcidump_path)[0]
-    elif len(glob.glob(fcidump_path)) == 0:
-        print("no matching fcidump file")
-    else:
-        print(f"multiple matches for {fcidump_path}")
-        for i in glob.glob(fcidump_path):
-            print(i)
-
-    # Use an iterator to avoid storing everything in memory twice.
-    if fcidump_path.split(".")[-1] == "gz":
-        import gzip
-
-        f = gzip.open(fcidump_path)
-    elif fcidump_path.split(".")[-1] == "bz2":
-        import bz2
-
-        f = bz2.open(fcidump_path)
-    else:
-        f = open(fcidump_path)
-
-    # Only non-zero integrals are stored in the fci_dump.
-    # Hence we use a defaultdict to handle the sparsity
-    n_orb = int(next(f).split()[2])
-
-    for _ in range(3):
-        next(f)
-
+    E0=0
+    n_elec =0
+    n_orb=0
     d_one_e_integral = defaultdict(int)
     d_two_e_integral = defaultdict(int)
 
-    for line in f:
-        v, *l = line.split()
-        v = float(v)
-        # Transform from Mulliken (ik|jl) to Dirac's <ij|kl> notation
-        # (swap indices)
-        i, k, j, l = list(map(int, l))
+    import glob
 
-        if i == 0:
-            E0 = v
-        elif j == 0:
-            # One-electron integrals are symmetric (when real, not complex)
-            d_one_e_integral[
-                (i - 1, k - 1)
-            ] = v  # index minus one to be consistent with determinant orbital indexing starting at zero
-            d_one_e_integral[(k - 1, i - 1)] = v
-        else:
-            # Two-electron integrals have many permutation symmetries:
-            # Exchange r1 and r2 (indices i,k and j,l)
-            # Exchange i,k
-            # Exchange j,l
-            key = compound_idx4(i - 1, j - 1, k - 1, l - 1)
-            d_two_e_integral[key] = v
+    if(rank==0): 
+       T_load_integrals_start = time.time()
+       if len(glob.glob(fcidump_path)) == 1:
+           fcidump_path = glob.glob(fcidump_path)[0]
+       elif len(glob.glob(fcidump_path)) == 0:
+           print("no matching fcidump file")
+       else:
+           print(f"multiple matches for {fcidump_path}")
+           for i in glob.glob(fcidump_path):
+               print(i)
+     
+       # Use an iterator to avoid storing everything in memory twice.
+       if fcidump_path.split(".")[-1] == "gz":
+           import gzip
+     
+           f = gzip.open(fcidump_path)
+       elif fcidump_path.split(".")[-1] == "bz2":
+           import bz2
+     
+           f = bz2.open(fcidump_path)
+       else:
+           f = open(fcidump_path)
+     
+       # Only non-zero integrals are stored in the fci_dump.
+       # Hence we use a defaultdict to handle the sparsity
+       split=next(f).split()
+       n_orb=int(split[2])
+       n_elec=int(split[5])
 
-    f.close()
+       for _ in range(3):
+           next(f)
+     
+       d_one_e_integral = defaultdict(int)
+       d_two_e_integral = defaultdict(int)
+     
+       for line in f:
+           v, *l = line.split()
+           v = float(v)
+           # Transform from Mulliken (ik|jl) to Dirac's <ij|kl> notation
+           # (swap indices)
+           i, k, j, l = list(map(int, l))
+     
+           if i == 0:
+               E0 = v
+           elif j == 0:
+               # One-electron integrals are symmetric (when real, not complex)
+               d_one_e_integral[
+                   (i - 1, k - 1)
+               ] = v  # index minus one to be consistent with determinant orbital indexing starting at zero
+               d_one_e_integral[(k - 1, i - 1)] = v
+           else:
+               # Two-electron integrals have many permutation symmetries:
+               # Exchange r1 and r2 (indices i,k and j,l)
+               # Exchange i,k
+               # Exchange j,l
+               key = compound_idx4(i - 1, j - 1, k - 1, l - 1)
+               d_two_e_integral[key] = v
+     
+       f.close()
+       T_load_integrals_stop = time.time()
+       print("Time load integrals =", T_load_integrals_stop-T_load_integrals_start)
 
-    return n_orb, E0, d_one_e_integral, d_two_e_integral
+    n_elec=comm.bcast(n_elec, root=0) 
+    n_orb=comm.bcast(n_orb, root=0) 
+    E0=comm.bcast(E0, root=0) 
+    d_one_e_integral=comm.bcast(d_one_e_integral, root=0) 
+    d_two_e_integral=comm.bcast(d_two_e_integral, root=0) 
+
+    return n_elec, n_orb, E0, d_one_e_integral, d_two_e_integral
 
 
-def load_wf(path_wf) -> Tuple[List[float], List[Determinant]]:
+
+def load_wf(n_elec,n_orb,path_wf) -> Tuple[List[float], List[Determinant]]:
     """Read the input file :
     Representation of the Slater determinants (basis) and
     vector of coefficients in this basis (wave function)."""
 
     import glob
-
-    if len(glob.glob(path_wf)) == 1:
-        path_wf = glob.glob(path_wf)[0]
-    elif len(glob.glob(path_wf)) == 0:
-        print(f"no matching wf file: {path_wf}")
-    else:
-        print(f"multiple matches for {path_wf}")
-        for i in glob.glob(path_wf):
-            print(i)
-
-    if path_wf.split(".")[-1] == "gz":
-        import gzip
-
-        with gzip.open(path_wf) as f:
-            data = f.read().decode().split()
-    elif path_wf.split(".")[-1] == "bz2":
-        import bz2
-
-        with bz2.open(path_wf) as f:
-            data = f.read().decode().split()
-    else:
-        with open(path_wf) as f:
-            data = f.read().split()
-
-    def decode_det(str_):
-        for i, v in enumerate(str_):
-            if v == "+":
-                yield i
-
-    def grouper(iterable, n):
-        "Collect data into fixed-length chunks or blocks"
-        args = [iter(iterable)] * n
-        return zip(*args)
+    comm=MPI.COMM_WORLD
+    rank=comm.Get_rank()
 
     det = []
     psi_coef = []
-    for (coef, det_i, det_j) in grouper(data, 3):
-        psi_coef.append(float(coef))
-        det.append(Determinant(tuple(decode_det(det_i)), tuple(decode_det(det_j))))
 
-    # Normalize psi_coef
+    if(rank==0): 
+       if (path_wf!="Guess"):
+          if len(glob.glob(path_wf)) == 1:
+              path_wf = glob.glob(path_wf)[0]
+          elif len(glob.glob(path_wf)) == 0:
+              print(f"no matching wf file: {path_wf}")
+          else:
+              print(f"multiple matches for {path_wf}")
+              for i in glob.glob(path_wf):
+                  print(i)
+      
+          if path_wf.split(".")[-1] == "gz":
+              import gzip
+      
+              with gzip.open(path_wf) as f:
+                  data = f.read().decode().split()
+          elif path_wf.split(".")[-1] == "bz2":
+              import bz2
+      
+              with bz2.open(path_wf) as f:
+                  data = f.read().decode().split()
+          else:
+              with open(path_wf) as f:
+                  data = f.read().split()
+      
+          def decode_det(str_):
+              for i, v in enumerate(str_):
+                  if v == "+":
+                      yield i
+      
+          def grouper(iterable, n):
+              "Collect data into fixed-length chunks or blocks"
+              args = [iter(iterable)] * n
+              return zip(*args)
+          for (coef, det_i, det_j) in grouper(data, 3):
+              psi_coef.append(float(coef))
+              det.append(Determinant(tuple(decode_det(det_i)), tuple(decode_det(det_j))))
+       else:
+          print("Bazinga")
+          coef=1.0
+          alpha=math.ceil(n_elec/2)
+          beta=n_elec-alpha
+          psi_coef.append(float(coef))
+          #$This is Wrong!!!! Needs fixing!!!!
+          det_i="+++++------" 
+          det_j="+++++------" 
+          det.append(Determinant(tuple(decode_det(det_i)), tuple(decode_det(det_j))))
+ 
+ 
+       # Normalize psi_coef
+ 
+       norm = math.sqrt(sum(c * c for c in psi_coef))
+       psi_coef = [c / norm for c in psi_coef]
 
-    norm = math.sqrt(sum(c * c for c in psi_coef))
-    psi_coef = [c / norm for c in psi_coef]
+    psi_coef=comm.bcast(psi_coef, root=0) 
+    det=comm.bcast(det, root=0) 
+
 
     return psi_coef, det
 


### PR DESCRIPTION
This PR addresses 2 items:
1- Load Integrals and Load WFN are now executed only by the master node then data is Broadcasted to other node removing the stress from the file system. 

2- The WFN file is not required to start the run unless for a restart. The determinants are guessed based on the number of electrons and the number of orbitals.  When present, the WFN is read by the master node and broadcasted to the remaining nodes. 