### PR TITLE
Program no longer assumes where integrals start in fcidump

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-!/usr/bin/env python3
+#!/usr/bin/env python3
 from qe.drivers import *
 from qe.io import *
 import sys

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+!/usr/bin/env python3
 from qe.drivers import *
 from qe.io import *
 import sys
@@ -35,11 +35,24 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     # Load integrals
-    n_ord, E0, d_one_e_integral, d_two_e_integral = load_integrals(args.fcidump_path)
-    # Load wave function
-    psi_coef, psi_det = load_wf(args.wf_path)
-    # Hamiltonian engine
     comm = MPI.COMM_WORLD
+    # Initialize rank
+    rank = comm.Get_rank()
+    # Only master will load integrals and wave functions
+    if rank == 0:
+        n_ord, E0, d_one_e_integral, d_two_e_integral = load_integrals(args.fcidump_path)
+        # Load wave function
+        psi_coef, psi_det = load_wf(args.wf_path)
+
+        # pack into tuple so it can be sent with bcast
+        load_tup = (n_ord, E0, d_one_e_integral, d_two_e_integral, psi_coef, psi_det)
+    else:
+        load_tup = None
+
+    # broadcast variables to all ranks
+    n_ord, E0, d_one_e_integral, d_two_e_integral, psi_coef, psi_det = comm.bcast(load_tup, 0)
+
+    # Hamiltonian engine
     lewis = Hamiltonian_generator(
         comm, E0, d_one_e_integral, d_two_e_integral, psi_det, driven_by=args.driven_by
     )

--- a/qe/io.py
+++ b/qe/io.py
@@ -9,6 +9,7 @@ from qe.fundamental_types import (
 from collections import defaultdict
 from qe.integral_indexing_utils import compound_idx4
 import math
+from itertools import takewhile
 
 #   _____      _ _   _       _ _          _   _
 #  |_   _|    (_) | (_)     | (_)        | | (_)
@@ -16,6 +17,12 @@ import math
 #    | || '_ \| | __| |/ _` | | |_  / _` | __| |/ _ \| '_ \
 #   _| || | | | | |_| | (_| | | |/ / (_| | |_| | (_) | | | |
 #   \___/_| |_|_|\__|_|\__,_|_|_/___\__,_|\__|_|\___/|_| |_|
+
+
+# Takes in the raw lines and manipulates them if needed based on using zip or not.
+def manipulate_line(raw_line, used_zip):
+    line = raw_line.decode("utf-8") if used_zip else raw_line
+    return line.strip()
 
 
 # ~
@@ -41,7 +48,7 @@ def load_integrals(
         for i in glob.glob(fcidump_path):
             print(i)
 
-    # Add used_zip boolean so we know if we need to decode the lines
+    # Add used_zip boolean so we know if we need to decode the lines.
     used_zip = True
 
     # Use an iterator to avoid storing everything in memory twice.
@@ -61,17 +68,9 @@ def load_integrals(
     # Hence we use a defaultdict to handle the sparsity
     n_orb = int(next(f).split()[2])
 
-    # Key were looking for
-    key = " /\n"
-    found = False
-    # Keep looping until the key is found
-    while not found:
-        # Read line
-        line = f.readline()
-        # Decode if needed
-        line = line.decode("utf-8") if used_zip else line
-        # Check if it equals the key
-        found = line == key
+    # Using takewhile we 'take lines from the file' while '/' has not been found
+    # Needed so we can start reading data on the integrals.
+    lines = list(takewhile(lambda line: "/" not in manipulate_line(line, used_zip), f))
 
     d_one_e_integral = defaultdict(int)
     d_two_e_integral = defaultdict(int)

--- a/qe/io.py
+++ b/qe/io.py
@@ -41,6 +41,9 @@ def load_integrals(
         for i in glob.glob(fcidump_path):
             print(i)
 
+    # Add used_zip boolean so we know if we need to decode the lines
+    used_zip = True
+
     # Use an iterator to avoid storing everything in memory twice.
     if fcidump_path.split(".")[-1] == "gz":
         import gzip
@@ -52,13 +55,23 @@ def load_integrals(
         f = bz2.open(fcidump_path)
     else:
         f = open(fcidump_path)
+        used_zip = False
 
     # Only non-zero integrals are stored in the fci_dump.
     # Hence we use a defaultdict to handle the sparsity
     n_orb = int(next(f).split()[2])
 
-    for _ in range(3):
-        next(f)
+    # Key were looking for
+    key = " /\n"
+    found = False
+    # Keep looping until the key is found
+    while not found:
+        # Read line
+        line = f.readline()
+        # Decode if needed
+        line = line.decode("utf-8") if used_zip else line
+        # Check if it equals the key
+        found = line == key
 
     d_one_e_integral = defaultdict(int)
     d_two_e_integral = defaultdict(int)


### PR DESCRIPTION
* Program doesn't assume where integrals start inside fcidump file. The number of 'orbsym' lines would crash the program if there was more than one line. Program now checks for a certain 'key' then starts reading the integrals. 